### PR TITLE
Bug fix in CrowdStrike audit script

### DIFF
--- a/Scripts/crowdstrike_falcon_ae_script.zsh
+++ b/Scripts/crowdstrike_falcon_ae_script.zsh
@@ -154,11 +154,11 @@ else
 fi
 
 # Get the falcon PID
-falcon_process_id="None"
+falcon_process_id=""
 loop_counter=0
 
 # Loop until the falcon pid is found or we have checked the status 5 times
-while [[ "$falcon_process_id" == "None" ]] && [[ "$loop_counter" -lt 6 ]]; do
+while [[ "$falcon_process_id" == "" ]] && [[ "$loop_counter" -lt 6 ]]; do
 
     # Get the falcon PID
     falcon_process_id="$(/usr/bin/pgrep com.crowdstrike.falcon.Agent)"


### PR DESCRIPTION
When the CrowdStike Falcon agent is not running, the query for the "falcon_process_id" on line 161 does not resolve to a "None" string value but instead to NULL / "". The while loop therefore breaks early as it expects "falcon_process_id" to be a string value of "Null" for it to continue. This causes the script to exit with code 0 and does not triggering a re-install of the agent, which is not running. I have tested this in our environment and the agent is now correctly re-installed when it's not running (usually due to issues with the KEXT/System Extensions profiles).