### PR TITLE
Fix InstallXcode.sh to handle headers from GCP

### DIFF
--- a/Scripts/InstallXcode.sh
+++ b/Scripts/InstallXcode.sh
@@ -79,7 +79,7 @@ downloadFile() {
 }
 
 getDownloadSize() {
-	/usr/bin/curl -sI "$finalURL" | /usr/bin/grep -i Content-Length | /usr/bin/awk '{print $2}' | /usr/bin/tr -d '\r'
+	/usr/bin/curl -sI "$finalURL" | /usr/bin/grep -i ^Content-Length | /usr/bin/awk '{print $2}' | /usr/bin/tr -d '\r'
 }
 
 dlPercent() {


### PR DESCRIPTION
GCP headers include both an `x-goog-stored-content-length` header and a `content-length` header. This results in `/usr/bin/grep -i ^Content-Length` returning 2 lines, instead of one, and causes further errors downstream. This change causes grep to only match on Content-Length occurring at the beginning of the line, resulting in only 1 line being returned.