### PR TITLE
Updates to Sophos Profiles

### DIFF
--- a/Configuration Profiles/Sophos_Central_Settings.mobileconfig
+++ b/Configuration Profiles/Sophos_Central_Settings.mobileconfig
@@ -99,7 +99,7 @@
 			<key>PayloadType</key>
 			<string>com.apple.TCC.configuration-profile-policy</string>
 			<key>PayloadUUID</key>
-			<string>AC89B7AD-8449-469B-AC21-19E34E2F6B1D</string>
+			<string>7FBDD7A8-C8CC-4916-88A1-62B73BF1EA63</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
 			<key>Services</key>
@@ -274,6 +274,20 @@
 						<key>StaticCode</key>
 						<false/>
 					</dict>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "com.sophos.macendpoint.Sophos-Installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2H5GFH3774"</string>
+						<key>Comment</key>
+						<string>All Sophos products</string>
+						<key>Identifier</key>
+						<string>com.sophos.macendpoint.Sophos-Installer</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<false/>
+					</dict>
 				</array>
 			</dict>
 		</dict>
@@ -291,7 +305,7 @@
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>
-	<string>AE58F9D6-E427-43AC-AD85-8513556A9E10</string>
+	<string>CAAE99E5-8653-4974-9BD6-9E4D1EBBCD3B</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
 </dict>

--- a/Configuration Profiles/Sophos_Central_Settings_with_KEXT.mobileconfig
+++ b/Configuration Profiles/Sophos_Central_Settings_with_KEXT.mobileconfig
@@ -127,7 +127,7 @@
 			<key>PayloadType</key>
 			<string>com.apple.TCC.configuration-profile-policy</string>
 			<key>PayloadUUID</key>
-			<string>E27E39AE-6367-425B-951C-D80D1D0CCBFD</string>
+			<string>EFB73626-25E5-4530-B746-80018A38B23B</string>
 			<key>PayloadVersion</key>
 			<integer>1</integer>
 			<key>Services</key>
@@ -288,6 +288,20 @@
 						<key>StaticCode</key>
 						<false/>
 					</dict>
+					<dict>
+						<key>Allowed</key>
+						<true/>
+						<key>CodeRequirement</key>
+						<string>identifier "com.sophos.macendpoint.Sophos-Installer" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "2H5GFH3774"</string>
+						<key>Comment</key>
+						<string>All Sophos products</string>
+						<key>Identifier</key>
+						<string>com.sophos.macendpoint.Sophos-Installer</string>
+						<key>IdentifierType</key>
+						<string>bundleID</string>
+						<key>StaticCode</key>
+						<false/>
+					</dict>
 				</array>
 			</dict>
 		</dict>
@@ -305,7 +319,7 @@
 	<key>PayloadType</key>
 	<string>Configuration</string>
 	<key>PayloadUUID</key>
-	<string>1e69d4c7-3bb2-44c3-a5c4-be0570305ebc</string>
+	<string>BEFA13DF-E06F-4B58-BD45-1DC2799C5B22</string>
 	<key>PayloadVersion</key>
 	<integer>1</integer>
 </dict>


### PR DESCRIPTION
Updated Sophos profiles for [kBase Documentation](https://support.kandji.io/support/solutions/articles/72000560513-deploy-sophos-endpoint-as-a-custom-app) to reflect new PPPC entry for the Sophos Installer app.