### PR TITLE
Give Falcon access to Bluetooth

### DIFF
--- a/custom-apps/crowdstrike/crowdstrike_settings.mobileconfig
+++ b/custom-apps/crowdstrike/crowdstrike_settings.mobileconfig
@@ -106,6 +106,33 @@
                             <false/>
                         </dict>
                     </array>
+                    <key>BluetoothAlways</key>
+                    <array>
+                        <dict>
+                            <key>Allowed</key>
+                            <true/>
+                            <key>CodeRequirement</key>
+                            <string>identifier "com.crowdstrike.falcon.Agent" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = "X9E956P446"</string>
+                            <key>Identifier</key>
+                            <string>com.crowdstrike.falcon.Agent</string>
+                            <key>IdentifierType</key>
+                            <string>bundleID</string>
+                            <key>StaticCode</key>
+                            <false/>
+                        </dict>
+                        <dict>
+                            <key>Allowed</key>
+                            <true/>
+                            <key>CodeRequirement</key>
+                            <string>identifier "com.crowdstrike.falcon.App" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] and certificate leaf[field.1.2.840.113635.100.6.1.13] and certificate leaf[subject.OU] = "X9E956P446"</string>
+                            <key>Identifier</key>
+                            <string>com.crowdstrike.falcon.App</string>
+                            <key>IdentifierType</key>
+                            <string>bundleID</string>
+                            <key>StaticCode</key>
+                            <false/>
+                        </dict>
+                    </array>
                 </dict>
             </dict>
             <dict>


### PR DESCRIPTION
Enables the Falcon sensor to access Bluetooth without requiring end-user interaction, ensuring consistent enforcement of Bluetooth device controls through CrowdStrike policies.

This avoids the following popup during deployment. 

<img width="543" height="486" alt="image" src="https://github.com/user-attachments/assets/6b03073d-af9e-4b8e-9224-44539701159c" />
